### PR TITLE
Fix Locale preventing project from loading in non-ReduxStore environments

### DIFF
--- a/extensions/Fakemon/Locale.js
+++ b/extensions/Fakemon/Locale.js
@@ -716,6 +716,8 @@ Locale can be confusing to some users, so accurate documentation should help exp
      * @param {string} matchKey
      */
     _filterArray(array, matchKey) {
+      if (array == null) return [];
+      
       if (array != []) {
         return array.map((/** @type {{ [x: string]: any; }} */ value) => {
           try {


### PR DESCRIPTION
In the `_filterArray` function, passing a `null` value results in the function throwing an error due to not being able to access the `map` property. This only occurs in non-ReduxStore environments (such as packaged projects).

This isn't the best solution, as the "Language Code <=> Name Conversions" section of the extension is made completely useless, but it's at least better than the project not loading.